### PR TITLE
added mapper.each() feature and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,39 @@ assert.deepEqual(result, {
   }
 });
 ```
+
+**map-factory** also provides the ```each()``` method to help work with arrays and multiple mappers. This is useful when child objects within your main object have the same structure.
+
+```js
+const createMapper = require("map-factory");
+const assert = require("assert");
+
+const source = {
+  one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+  two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+  three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
+};
+
+const mainMapper = createMapper();
+const childMapper = createMapper();
+
+childMapper
+  .map("value").to("item");
+
+mainMapper
+  .map("one").to("one", array => childMapper.each(array))
+  .map("two").to("two", array => childMapper.each(array))
+  .map("three").to("three", array => childMapper.each(array));
+
+const actual = mainMapper.execute(source);
+
+assert.deepEqual(actual, {
+  one: [{item: "a" }, {item: "b" }, {item: "c" }],
+  two: [{item: "a" }, {item: "b" }, {item: "c" }],
+  three: [{item: "a" }, {item: "b" }, {item: "c" }]
+});
+```
+
 ### Transformations
 More complicated transformations can be handled by providing a function. The selected source data will be passed to the function.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ mapper
   .map("sourceField").to("source.field")
   .map("sourceId").to("source.id");
 
-const result = map.execute(source);
+const result = mapper.execute(source);
 ```
 
 ## Examples

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -10,7 +10,7 @@ export interface IMapData {
 export interface IMapFactory {
   (stringOrArray: string | string[]): IMapping;
   map(stringOrArray: string | string[]): IMapping;
-  execute(source?, destination?);
+  execute(source, destination?);
   each(sourceArray);
 }
 
@@ -19,7 +19,7 @@ export interface IMapping {
   target: string | IKeyDefinition;
   to(target: string, fnc?: Function);
   map(stringOrArray: string | string[]): IMapping;
-  execute(source?, destination?);
-  each(sourceArray?);
+  execute(source, destination?);
+  each(sourceArray);
 
 }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -11,7 +11,7 @@ export interface IMapFactory {
   (stringOrArray: string | string[]): IMapping;
   map(stringOrArray: string | string[]): IMapping;
   execute(source, destination?);
-  each(sourceArray);
+  each(sourceArray: any[]);
 }
 
 export interface IMapping {
@@ -20,6 +20,6 @@ export interface IMapping {
   to(target: string, fnc?: Function);
   map(stringOrArray: string | string[]): IMapping;
   execute(source, destination?);
-  each(sourceArray);
+  each(sourceArray: any[]);
 
 }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -11,6 +11,7 @@ export interface IMapFactory {
   (stringOrArray: string | string[]): IMapping;
   map(stringOrArray: string | string[]): IMapping;
   execute(source?, destination?);
+  each(sourceArray);
 }
 
 export interface IMapping {
@@ -19,5 +20,6 @@ export interface IMapping {
   to(target: string, fnc?: Function);
   map(stringOrArray: string | string[]): IMapping;
   execute(source?, destination?);
+  each(sourceArray?);
 
 }

--- a/lib/map-factory.ts
+++ b/lib/map-factory.ts
@@ -19,11 +19,11 @@ export default function createMapper(): IMapFactory {
 
   }.bind(me);
 
-  mapper.execute = function (source?, destination?) {
+  mapper.execute = function (source, destination?) {
     return this.mapper.execute(source, destination);
   }.bind(me);
 
-  mapper.each = function (sourceArray?) {
+  mapper.each = function (sourceArray: any[]) {
     return this.mapper.each(sourceArray);
   }.bind(me);
 

--- a/lib/map-factory.ts
+++ b/lib/map-factory.ts
@@ -23,5 +23,9 @@ export default function createMapper(): IMapFactory {
     return this.mapper.execute(source, destination);
   }.bind(me);
 
+  mapper.each = function (sourceArray?) {
+    return this.mapper.each(sourceArray);
+  }.bind(me);
+
   return mapper;
 }

--- a/lib/mapper.ts
+++ b/lib/mapper.ts
@@ -23,6 +23,22 @@ export default class Mapper {
 
   }
 
+  public each(sourceArray: any[]) {
+
+    if (sourceArray === null || sourceArray === undefined) {
+      throw new Error("A sourceArray object is required");
+    }
+
+    if (Array.isArray(sourceArray) !== true) {
+      throw new Error("The sourceArray parameter must be an array");
+    }
+
+    return sourceArray.map(item => {
+      return this.execute(item, null);
+    });
+
+  }
+
   public execute(source, destination) {
 
     if (source === null || source === undefined) {

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -25,6 +25,10 @@ export default class Mapping implements IMapping {
     return this.mapper.execute(source, destination);
   }
 
+  public each(sourceArray) {
+    return this.mapper.each(sourceArray);
+  }
+
   public to(target: string, fnc?: Function) {
 
     if (!target) {

--- a/test/examples-test.ts
+++ b/test/examples-test.ts
@@ -153,7 +153,36 @@ const exampleGroup: nodeunit.ITestGroup = {
 
     return test.done();
   },
+  "provides the each() method to help work with arrays and multiple mappers": function (test: nodeunit.Test): void {
+    const source = {
+      one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+      two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+      three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
+    };
 
+    const expected = {
+      one: [{item: "a" }, {item: "b" }, {item: "c" }],
+      two: [{item: "a" }, {item: "b" }, {item: "c" }],
+      three: [{item: "a" }, {item: "b" }, {item: "c" }]
+    };
+
+    const mainMapper = createMapper();
+    const childMapper = createMapper();
+
+    childMapper
+      .map("value").to("item");
+
+    mainMapper
+      .map("one").to("one", array => childMapper.each(array))
+      .map("two").to("two", array => childMapper.each(array))
+      .map("three").to("three", array => childMapper.each(array));
+
+    const actual = mainMapper.execute(source);
+
+    test.deepEqual(actual, expected);
+
+    return test.done();
+  },
   "More complicated transformations can be handled by providing a function": function (test: nodeunit.Test): void {
 
     const expected = {

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -26,6 +26,24 @@ const basicMappingGroup: nodeunit.ITestGroup = {
     test.deepEqual(actual, expected);
 
     return test.done();
+  },
+  "each method works from the index": function (test: nodeunit.Test): void {
+
+    const source = [{
+      "fieldName": "name1"
+    }];
+
+    const expected = [{
+      "fieldName": "name1"
+    }];
+
+    const map = createMapper();
+
+    const actual = map("fieldName").each(source);
+
+    test.deepEqual(actual, expected);
+
+    return test.done();
   }
 };
 

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -307,7 +307,7 @@ const defaultGroup: nodeunit.ITestGroup = {
     map("fieldName").to("field.name");
 
     test.throws(() => {
-      const actual = map.execute();
+      const actual = map.execute(null);
     });
 
     return test.done();

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -264,11 +264,12 @@ const eachGroup: nodeunit.ITestGroup = {
   },
   "A non-array throws an error": function (test: nodeunit.Test): void {
     const map = createMapper();
+    const source: any = {"a": "b"};
 
     map("fieldName").to("field.name");
 
     test.throws(() => {
-      const actual = map.each({"a": "b"});
+      const actual = map.each(source);
     });
 
     return test.done();
@@ -299,8 +300,7 @@ const defaultGroup: nodeunit.ITestGroup = {
 
     return test.done();
   },
-
-  "Throws if no source is provided": function (test: nodeunit.Test): void {
+  "Throws if a null source is provided": function (test: nodeunit.Test): void {
 
     const map = createMapper();
 
@@ -312,7 +312,18 @@ const defaultGroup: nodeunit.ITestGroup = {
 
     return test.done();
   },
+  "Throws if an undefined source is provided": function (test: nodeunit.Test): void {
 
+    const map = createMapper();
+
+    map("fieldName").to("field.name");
+
+    test.throws(() => {
+      const actual = map.execute(undefined);
+    });
+
+    return test.done();
+  },
   "Can reuse the map for multiple transforms": function (test: nodeunit.Test): void {
 
     const source = {

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -172,6 +172,108 @@ const fluentChainingGroup: nodeunit.ITestGroup = {
 
 };
 
+const eachGroup: nodeunit.ITestGroup = {
+
+  "Can process an array correctly": function (test: nodeunit.Test): void {
+    const source = [{
+      "fieldName": "name1"
+    }, {
+      "fieldName": "name2"
+    }];
+
+    const expected = [
+      {
+        "field": {
+          "name": "name1"
+        }
+      },
+      {
+        "field": {
+          "name": "name2"
+        }
+      }];
+
+    const map = createMapper();
+
+    map("fieldName").to("field.name");
+
+    const actual = map.each(source);
+
+    test.deepEqual(actual, expected);
+
+    return test.done();
+
+  },
+  "An empty array does not cause an error": function (test: nodeunit.Test): void {
+    const source = [];
+
+    const expected = [];
+
+    const map = createMapper();
+
+    map("fieldName").to("field.name");
+
+    const actual = map.each(source);
+
+    test.deepEqual(actual, expected);
+
+    return test.done();
+
+  },
+  "Multiple mappers can be used together": function (test: nodeunit.Test): void {
+    const source = {
+      one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+      two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
+      three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
+    };
+
+    const expected = {
+      one: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
+      two: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
+      three: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }]
+    };
+
+    const mainMapper = createMapper();
+    const childMapper = createMapper();
+
+    childMapper
+      .map("value").to("newOne");
+
+    mainMapper
+      .map("one").to("one", array => childMapper.each(array))
+      .map("two").to("two", array => childMapper.each(array))
+      .map("three").to("three", array => childMapper.each(array));
+
+    const actual = mainMapper.execute(source);
+
+    test.deepEqual(actual, expected);
+
+    return test.done();
+
+  },
+  "A null parameter throws an error": function (test: nodeunit.Test): void {
+    const map = createMapper();
+
+    map("fieldName").to("field.name");
+
+    test.throws(() => {
+      const actual = map.each(null);
+    });
+
+    return test.done();
+  },
+  "A non-array throws an error": function (test: nodeunit.Test): void {
+    const map = createMapper();
+
+    map("fieldName").to("field.name");
+
+    test.throws(() => {
+      const actual = map.each({"a": "b"});
+    });
+
+    return test.done();
+  }
+};
 
 const defaultGroup: nodeunit.ITestGroup = {
 
@@ -199,12 +301,6 @@ const defaultGroup: nodeunit.ITestGroup = {
   },
 
   "Throws if no source is provided": function (test: nodeunit.Test): void {
-
-    const expected = {
-      "field": {
-        "name": "name1"
-      }
-    };
 
     const map = createMapper();
 
@@ -555,3 +651,4 @@ exports.sourceAndDestination = sourceAndDestinationGroup;
 exports.customFunctions = customFunctionsGroup;
 exports.multipleSelection = multipleSelectionGroup;
 exports.fluentChaining = fluentChainingGroup;
+exports.each = eachGroup;


### PR DESCRIPTION
@blacksun1 This is just a a convenience method to make working with multiple mappers easier. It's useful when the object structures when the child objects have the same structure but the main object structure doesn't lend itself to a single dot notation query.

```js
    const source = {
      one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
      two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
      three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
    };

    const expected = {
      one: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
      two: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
      three: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }]
    };

    const mainMapper = createMapper();
    const childMapper = createMapper();

    childMapper
      .map("value").to("newOne");

    mainMapper
      .map("one").to("one", array => childMapper.each(array))
      .map("two").to("two", array => childMapper.each(array))
      .map("three").to("three", array => childMapper.each(array));

    const actual = mainMapper.execute(source);
``` 