### PR TITLE
Added or() method

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -15,10 +15,12 @@ export interface IMapFactory {
 }
 
 export interface IMapping {
+  orMode: boolean;
   source: string | string[];
   target: string | IKeyDefinition;
   to(target: string, fnc?: Function);
   map(stringOrArray: string | string[]): IMapping;
+  or(source: string);
   execute(source, destination?);
   each(sourceArray: any[]);
 

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -5,6 +5,7 @@ export default class Mapping implements IMapping {
   public source: string | string[];
   public target: string | IKeyDefinition;
   public mapper: any;
+  public orMode: boolean = false;
 
   constructor(source: string | string[], mapper) {
 
@@ -19,6 +20,32 @@ export default class Mapping implements IMapping {
 
   public map(stringOrArray: string | string[]) {
     return this.mapper.map(stringOrArray);
+  }
+
+  public or(source: string) {
+
+    if (!source) {
+      throw new Error("'source' is required for the 'or' method");
+    }
+
+    if (Array.isArray(source)) {
+      throw new Error("The 'or' method can only be used with single selections");
+    }
+
+    if (Array.isArray(this.source) && this.orMode === false) {
+      throw new Error("The 'or' method can only be used with single selections");
+    }
+
+    this.orMode = true;
+
+    const newSource = [];
+    newSource.push(this.source);
+    newSource.push(source);
+
+    this.source = newSource;
+
+    return this;
+
   }
 
   public execute(source?, destination?) {

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -38,6 +38,16 @@ export default class Mapping implements IMapping {
 
     this.orMode = true;
 
+    if (Array.isArray(this.source)) {
+
+      const sourceArray: any = this.source;
+
+      sourceArray.push(source);
+
+
+      return this;
+    }
+
     const newSource = [];
     newSource.push(this.source);
     newSource.push(source);

--- a/test/examples-test.ts
+++ b/test/examples-test.ts
@@ -1,6 +1,8 @@
 import * as nodeunit from "nodeunit";
 // tslint:disable-next-line:no-require-imports
 const createMapper = require("../lib/index");
+// tslint:disable-next-line:no-require-imports
+const assert = require("assert");
 
 
 const exampleGroup: nodeunit.ITestGroup = {
@@ -90,10 +92,10 @@ const exampleGroup: nodeunit.ITestGroup = {
           "id": 1,
           "name": "game-1"
         },
-          {
-            "id": 2,
-            "name": "game-2"
-          }]
+        {
+          "id": 2,
+          "name": "game-2"
+        }]
       }
     };
 
@@ -156,15 +158,15 @@ const exampleGroup: nodeunit.ITestGroup = {
   },
   "provides the each() method to help work with arrays and multiple mappers": function (test: nodeunit.Test): void {
     const source = {
-      one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
-      two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
-      three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
+      one: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }],
+      two: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }],
+      three: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }]
     };
 
     const expected = {
-      one: [{item: "a" }, {item: "b" }, {item: "c" }],
-      two: [{item: "a" }, {item: "b" }, {item: "c" }],
-      three: [{item: "a" }, {item: "b" }, {item: "c" }]
+      one: [{ item: "a" }, { item: "b" }, { item: "c" }],
+      two: [{ item: "a" }, { item: "b" }, { item: "c" }],
+      three: [{ item: "a" }, { item: "b" }, { item: "c" }]
     };
 
     const mainMapper = createMapper();
@@ -426,6 +428,26 @@ const exampleGroup: nodeunit.ITestGroup = {
     // End example
 
     test.deepEqual(result, expected);
+    test.done();
+  },
+  "or method example": function (test: nodeunit.Test) {
+
+    const source = {
+      "leasee": "Mr. Man"
+    };
+
+    const map = createMapper();
+
+    map("occupier").or("leasee").or("tenant").to("occupier");
+
+    const result = map.execute(source);
+
+
+
+    assert.deepEqual(result, {
+      "occupier": "Mr. Man"
+    });
+
     test.done();
   }
 

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -222,15 +222,15 @@ const eachGroup: nodeunit.ITestGroup = {
   },
   "Multiple mappers can be used together": function (test: nodeunit.Test): void {
     const source = {
-      one: [{value: "a", drop: "me" }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
-      two: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }],
-      three: [{value: "a", drop: "me"  }, {value: "b", drop: "me"  }, {value: "c", drop: "me"  }]
+      one: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }],
+      two: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }],
+      three: [{ value: "a", drop: "me" }, { value: "b", drop: "me" }, { value: "c", drop: "me" }]
     };
 
     const expected = {
-      one: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
-      two: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }],
-      three: [{newOne: "a" }, {newOne: "b" }, {newOne: "c" }]
+      one: [{ newOne: "a" }, { newOne: "b" }, { newOne: "c" }],
+      two: [{ newOne: "a" }, { newOne: "b" }, { newOne: "c" }],
+      three: [{ newOne: "a" }, { newOne: "b" }, { newOne: "c" }]
     };
 
     const mainMapper = createMapper();
@@ -264,7 +264,7 @@ const eachGroup: nodeunit.ITestGroup = {
   },
   "A non-array throws an error": function (test: nodeunit.Test): void {
     const map = createMapper();
-    const source: any = {"a": "b"};
+    const source: any = { "a": "b" };
 
     map("fieldName").to("field.name");
 
@@ -624,7 +624,7 @@ const multipleSelectionGroup: nodeunit.ITestGroup = {
     return test.done();
   },
 
-  "If Multiple selections aren't mapped to a transform and error will occur": function (test: nodeunit.Test): void {
+  "If multiple selections aren't mapped to a transform and error will occur": function (test: nodeunit.Test): void {
 
     const source = {
       "person": {
@@ -656,6 +656,148 @@ const multipleSelectionGroup: nodeunit.ITestGroup = {
   }
 };
 
+const orMethodGroup: nodeunit.ITestGroup = {
+
+  "Maps the first item if it is present": function (test: nodeunit.Test): void {
+
+    const source = {
+      "fieldName": "name1"
+    };
+
+    const expected = {
+      "field": {
+        "name": "name1"
+      }
+    };
+
+    const map = createMapper();
+
+    map("fieldName").or("noField").to("field.name");
+
+    const actual = map.execute(source);
+
+    test.deepEqual(actual, expected, "or method has not selected the first item.");
+
+    return test.done();
+
+  },
+  "to method can use a transform if provided with first item": function (test: nodeunit.Test): void {
+    const source = {
+      "fieldName": "name1"
+    };
+
+    const expected = {
+      "field": {
+        "name": "altered name1"
+      }
+    };
+
+    const map = createMapper();
+
+    map("fieldName").or("noField").to("field.name", value => `altered ${value}`);
+
+    const actual = map.execute(source);
+
+    test.deepEqual(actual, expected, "or method has not selected the first item.");
+
+    return test.done();
+  },
+  "Maps the second item if the first item isn't present": function (test: nodeunit.Test): void {
+
+    const source = {
+      "fieldName": "name1"
+    };
+
+    const expected = {
+      "field": {
+        "name": "name1"
+      }
+    };
+
+    const map = createMapper();
+
+    map("noField").or("fieldName").to("field.name");
+
+    const actual = map.execute(source);
+
+    test.deepEqual(actual, expected, "or method has not selected the second item.");
+
+    return test.done();
+  },
+  "to method can use a transform if provided with subsequent item": function (test: nodeunit.Test): void {
+    const source = {
+      "fieldName": "name1"
+    };
+
+    const expected = {
+      "field": {
+        "name": "altered name1"
+      }
+    };
+
+    const map = createMapper();
+
+    map("noField").or("fieldName").to("field.name", value => `altered ${value}`);
+
+    const actual = map.execute(source);
+
+    test.deepEqual(actual, expected, "or method has not selected the first item.");
+
+    return test.done();
+  },
+  "Throws if the initial source field is an array": function (test: nodeunit.Test): void {
+
+    const map = createMapper();
+
+
+    test.throws(() => {
+
+      map(["a", "b"]).or("fieldName").to("field.name");
+
+    });
+
+    test.done();
+
+    
+  },
+  "Throws if and subsequent source field is an array": function (test: nodeunit.Test): void {
+
+    const map:any = createMapper();
+
+    test.throws(() => {
+
+      map("fieldName").or(["a", "b"]).to("field.name");
+
+    });
+
+    test.done();
+  },
+  "Throws if source is null": function (test: nodeunit.Test): void {
+    const map: any = createMapper();
+
+    test.throws(() => {
+
+      map("fieldName").or(null).to("field.name");
+
+    });
+
+    test.done();
+
+  },
+  "Throws if source is undefined": function (test: nodeunit.Test): void {
+    const map: any = createMapper();
+
+    test.throws(() => {
+
+      map("fieldName").or(undefined).to("field.name");
+
+    });
+
+    test.done();
+
+  }
+};
+
 exports.basicMapping = defaultGroup;
 exports.mapMethod = mapGroup;
 exports.sourceAndDestination = sourceAndDestinationGroup;
@@ -663,3 +805,4 @@ exports.customFunctions = customFunctionsGroup;
 exports.multipleSelection = multipleSelectionGroup;
 exports.fluentChaining = fluentChainingGroup;
 exports.each = eachGroup;
+exports.orMethod = orMethodGroup;

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -758,11 +758,10 @@ const orMethodGroup: nodeunit.ITestGroup = {
 
     test.done();
 
-    
   },
   "Throws if and subsequent source field is an array": function (test: nodeunit.Test): void {
 
-    const map:any = createMapper();
+    const map: any = createMapper();
 
     test.throws(() => {
 

--- a/test/map-factory-test.ts
+++ b/test/map-factory-test.ts
@@ -724,6 +724,28 @@ const orMethodGroup: nodeunit.ITestGroup = {
 
     return test.done();
   },
+  "Maps the last item in a very long chain": function (test: nodeunit.Test): void {
+
+    const source = {
+      "fieldName": "name1"
+    };
+
+    const expected = {
+      "field": {
+        "name": "name1"
+      }
+    };
+
+    const map = createMapper();
+
+    map("a").or("b").or("c").or("d").or("e").or("fieldName").to("field.name");
+
+    const actual = map.execute(source);
+
+    test.deepEqual(actual, expected, "or method has not selected the second item.");
+
+    return test.done();
+  },
   "to method can use a transform if provided with subsequent item": function (test: nodeunit.Test): void {
     const source = {
       "fieldName": "name1"


### PR DESCRIPTION
This allows you to specify a primary and secondary location to find a piece of data in a source object. It cannot be used in conjunction with selecting from multiple sources. Supports transforms too.

```js

map("a").or("b").or("c").or("d").to("value");

```