### PR TITLE
[Return null if source array is blank]

### DIFF
--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -29,18 +29,17 @@ export default class Mapper {
 
   each(sourceArray) {
 
-    if (sourceArray === null || sourceArray === undefined) {
-      throw new Error("A sourceArray object is required");
-    }
-
     if (Array.isArray(sourceArray) !== true) {
       throw new Error("The sourceArray parameter must be an array");
     }
 
-    return sourceArray.map(item => {
-      return this.execute(item, null);
-    });
+    if (sourceArray.length > 0) {
+      return sourceArray.map(item => {
+        return this.execute(item, null);
+      });
+    }
 
+    return null;
   }
 
   // execute(source, destination) {

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -29,6 +29,10 @@ export default class Mapper {
 
   each(sourceArray) {
 
+    if (!sourceArray) {
+      return null;
+    }
+
     if (Array.isArray(sourceArray) !== true) {
       throw new Error("The sourceArray parameter must be an array");
     }

--- a/src/test/map-factory-test.js
+++ b/src/test/map-factory-test.js
@@ -527,16 +527,12 @@ group("The each() method", () => {
 
   });
 
-  lab.test("A null parameter throws an error", done => {
+  lab.test("A null parameter should return null", done => {
     const map = createMapper();
 
     map("fieldName").to("field.name");
 
-    const throws = function () {
-      map.each(null);
-    };
-
-    expect(throws).to.throw();
+    expect(map.each(null)).to.equal(null);
 
     return done();
   });

--- a/src/test/map-factory-test.js
+++ b/src/test/map-factory-test.js
@@ -481,7 +481,7 @@ group("The each() method", () => {
   lab.test("An empty array does not cause an error", done => {
     const source = [];
 
-    const expected = [];
+    const expected = null;
 
     const map = createMapper();
 


### PR DESCRIPTION
If a blank array is passed in each method, the method should return a null and should not set the filed for which the transformation is called.

```
var source = {
  "foo":"bar",
  "fooArray": []
};

var mapper = createMapper();

var arrayMapper = createMapper();

arrayMapper
  .map("foo");

mapper
  .map("foo")
  .map("fooArray").to("array", function(array){
    return arrayMapper.each(array);
});
```

Actual Result
```
{
  "foo": "bar",
"fooArray": []
}
```


Expected Result
```
{
  "foo": "bar"
}
```
