### PR TITLE
removing object-mapper dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "object-mapper": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/lib/map-factory.js
+++ b/src/lib/map-factory.js
@@ -1,11 +1,10 @@
 import ported from "./object-mapper/object-mapper";
-import original from "object-mapper";
 import Mapper from "./mapper";
 
 export default function createMapper(options) {
 
   const opts = options || {};
-  const om = (opts.experimental) ? ported : original;
+  const om = ported;
 
   const me = {
     mapper: new Mapper(opts.experimental, om)


### PR DESCRIPTION
This PR removes the dependency on object-mapper and fixes a bug with empty objects created inside arrays.

I want to get more control over the mapping behaviour and this is the first step achieving that.