### PR TITLE
Bug fix for always and existing modifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cover": "istanbul cover ./node_modules/lab/bin/lab ./dist/test --leaks",
     "coveralls": "cat ./coverage/lcov.info | node ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "pretest": "npm run build",
-    "test": "lab ./dist/test/ -v -S --assert code",
+    "test": "./node_modules/lab/bin/lab ./dist/test/ -v -S --assert code",
     "pret": "npm run build",
     "t": "./test-one",
     "travis": "npm run test",

--- a/src/test/options-test.js
+++ b/src/test/options-test.js
@@ -2,6 +2,8 @@ import { expect } from "code";
 import * as Lab from "lab";
 import getHelper from "lab-testing";
 import createMapper from "../lib/index";
+import existingSuite from "./suites/existing-modifier-suite";
+import alwaysSuite from "./suites/always-modifier-suite";
 
 const lab = exports.lab = Lab.script();
 const testing = getHelper(lab);
@@ -95,7 +97,7 @@ group("when setting options", () => {
 
 });
 
-group("when executing with options set the single source mapper", () => {
+group("when executing with options set, the single source mapper", () => {
 
   lab.test("suppresses a transform when the source value is not present", done => {
 
@@ -261,7 +263,7 @@ group("when executing with options set the single source mapper", () => {
 
 });
 
-group("when executing with options set the multi source mapper", () => {
+group("when executing with options set, the multi source mapper", () => {
 
   lab.test("suppresses a transform when the source values are all not present", done => {
 
@@ -342,3 +344,24 @@ group("when executing with options set the multi source mapper", () => {
   });
 });
 
+group("the always modifier", () => {
+
+  alwaysSuite.run(lab, { OPTIONS: null });
+  alwaysSuite.run(lab, { });
+  alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: false } });
+  alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
+  alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: true, alwaysSet: false } });
+  alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
+
+});
+
+group("the existing modifier", () => {
+
+  existingSuite.run(lab, { OPTIONS: null });
+  existingSuite.run(lab, { });
+  existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: false } });
+  existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
+  existingSuite.run(lab, { OPTIONS: { alwaysTransform: true, alwaysSet: false } });
+  existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
+
+});

--- a/src/test/options-test.js
+++ b/src/test/options-test.js
@@ -302,6 +302,81 @@ group("when executing with options set, the multi source mapper", () => {
 
   });
 
+  lab.test("suppresses a set if a transform returns null", done => {
+
+    const source = {
+      "my": {
+        "source": {
+          "is": {}
+        },
+        "other": {
+          "source": {
+            "is": {
+              "here": "value"
+            }
+          }
+        }
+      }
+    };
+
+    const expected = {
+    };
+
+    const map = createMapper({ alwaysTransform: false, alwaysSet: false });
+    let count = 0;
+
+    map(["my.source.is.missing", "my.other.source.is.here"]).to("your.source.is.missing", () => {
+      count++;
+      return null;
+    });
+
+    const actual = map.execute(source);
+
+    expect(actual).to.equal(expected);
+    expect(count).to.equal(1);
+
+    return done();
+
+  });
+
+  lab.test("suppresses a set if a transform returns undefined", done => {
+
+    const source = {
+      "my": {
+        "source": {
+          "is": {}
+        },
+        "other": {
+          "source": {
+            "is": {
+              "here": "value"
+            }
+          }
+        }
+      }
+    };
+
+    const expected = {
+    };
+
+    const map = createMapper({ alwaysTransform: false, alwaysSet: false });
+
+    let count = 0;
+
+    map(["my.source.is.missing", "my.other.source.is.here"]).to("your.source.is.missing", () => {
+      count++;
+      return undefined;
+    });
+
+    const actual = map.execute(source);
+
+    expect(actual).to.equal(expected);
+    expect(count).to.equal(1);
+
+    return done();
+
+  });
+
   lab.test("a transform executes when one source value is present", done => {
 
     const source = {
@@ -344,10 +419,55 @@ group("when executing with options set, the multi source mapper", () => {
   });
 });
 
+group("when executing with options set, the or-mode source map", () => {
+
+  lab.test("a transform executes when one source value is present in or mode", done => {
+
+    const source = {
+      "my": {
+        "source": {
+          "is": {
+            "here": "value"
+          }
+        },
+        "other": {
+          "source": {
+            "is": {}
+          }
+        }
+      }
+    };
+
+    const expected = {
+      "your": {
+        "source": {
+          "is": {
+            "here": "found"
+          }
+        }
+      }
+    };
+
+    const map = createMapper({ alwaysTransform: false, alwaysSet: true });
+
+    map("my.source.is.here").or("my.other.source.is.missing").to("your.source.is.here", () => {
+      return "found";
+    });
+
+    const actual = map.execute(source);
+
+    expect(actual).to.equal(expected);
+
+    return done();
+
+  });
+
+});
+
 group("the always modifier", () => {
 
   alwaysSuite.run(lab, { OPTIONS: null });
-  alwaysSuite.run(lab, { });
+  alwaysSuite.run(lab, {});
   alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: false } });
   alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
   alwaysSuite.run(lab, { OPTIONS: { alwaysTransform: true, alwaysSet: false } });
@@ -358,7 +478,7 @@ group("the always modifier", () => {
 group("the existing modifier", () => {
 
   existingSuite.run(lab, { OPTIONS: null });
-  existingSuite.run(lab, { });
+  existingSuite.run(lab, {});
   existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: false } });
   existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
   existingSuite.run(lab, { OPTIONS: { alwaysTransform: true, alwaysSet: false } });

--- a/src/test/suites/always-modifier-suite.js
+++ b/src/test/suites/always-modifier-suite.js
@@ -1,0 +1,46 @@
+import { expect } from "code";
+import * as labSuite from "lab-suite";
+
+import createMapper from "../../lib/map-factory";
+
+const suite = labSuite.create();
+
+suite.expect("OPTIONS").to.be.an.anything();
+
+suite.declare((lab, variables) => {
+
+  const {
+    OPTIONS
+    } = variables;
+
+  lab.test(`overrides the default alwaysTransform behaviour with options ${JSON.stringify(OPTIONS)}`, done => {
+
+    const source = {
+      "my": {
+        "source": {
+          "is": {}
+        }
+      }
+    };
+
+    const expected = {
+    };
+
+    const map = createMapper(OPTIONS);
+
+    map("my.source.is.missing").existing.to("your.source.is.missing", () => {
+      return "failed";
+    });
+
+    const actual = map.execute(source);
+
+    expect(actual).to.equal(expected);
+
+    return done();
+
+  });
+
+
+});
+
+export default suite;

--- a/src/test/suites/existing-modifier-suite.js
+++ b/src/test/suites/existing-modifier-suite.js
@@ -1,0 +1,53 @@
+import { expect } from "code";
+import * as labSuite from "lab-suite";
+
+import createMapper from "../../lib/map-factory";
+
+const suite = labSuite.create();
+
+suite.expect("OPTIONS").to.be.an.anything();
+
+suite.declare((lab, variables) => {
+
+  const {
+    OPTIONS
+    } = variables;
+
+  lab.test(`overrides the default alwaysTransform behaviour with options ${JSON.stringify(OPTIONS)}`, done => {
+
+    const source = {
+      "my": {
+        "source": {
+          "is": {}
+        }
+      }
+    };
+
+    const expected = {
+      "your": {
+        "source": {
+          "is": {
+            "here": "success"
+          }
+        }
+      }
+    };
+
+    const map = createMapper(OPTIONS);
+
+    map("my.source.is.missing").always.to("your.source.is.here", () => {
+      return "success";
+    });
+
+    const actual = map.execute(source);
+
+    expect(actual).to.equal(expected);
+
+    return done();
+
+  });
+
+
+});
+
+export default suite;


### PR DESCRIPTION
Went on holiday. Thought I wrote some code before holiday. Turns out I hadn't.  :frowning_face: 

This makes ```always``` and ```existing``` modifiers work.