### PR TITLE
V2: Change default behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+### 2.0.0
+
+In ```v1``` the default behaviour was the equivalent of setting the options as ```{alwaysTransform: true, alwaysSet: true}```. In ```v2``` the default behaviour is now the equivalent of setting the options as ```{alwaysTransform: false, alwaysSet: false}```. 
+
+We feel these are generally better defaults. This is a **breaking** change.
+
+If you prefer the ```v1``` behaviour you just need to change your code as follows:
+
+#### Old Code
+```js
+const mapper = createMapper();
+```
+
+#### New Code
+```js
+const options = {
+  alwaysTransform: true,
+  alwaysSet: true
+};
+
+const mapper = createMapper(options);
+```
+
+Additionally, the ```v1``` behaviour would consider a null an acceptable value if a ```?``` was appended to the ```to()``` field. In ```v2``` this behaviour will only work in combination with the ```always``` flag.
+
+#### Old Code
+```js
+map("foo.bar").to("bar.bar?");
+```
+
+#### New Code
+```js
+map("foo.bar").always.to("bar.bar?");
+```
+
 ### 1.7.2
 
 Bug-fix to make *or mode* respect behaviour modifiers. 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ const result = mapper.execute(source);
 
 By default, **map-factory** will: 
 
-- always call a transform if one has been provided even if no source value was found in the source object.
-- always create a nested structure even if no source value was found on the source object. 
+- only call a transform (if one has been provided) if a source value was found in the source object.
+- only create a nested structure if a source value was found on the source object. 
 
 While this default is good some use cases it is not suitable for all use cases. To cater for this, behaviour modifiers are available.
 
 ### Modify default behaviour
 
-The ```createMapper()``` function now takes an (optional) options parameter to change the default behaviour.
+The ```createMapper()``` function takes an (optional) options parameter that will override the default behaviour.
 
-- **alwaysTransform: boolean** 
+- **alwaysTransform: boolean**
   - if *true* then a transform will always be called even if the source value was not available on the source object.
   - if *false* then a transform will only be called if the source value was available on the source object.
 
-- **alwaysSet: boolean** 
+- **alwaysSet: boolean**
   - if *true* then nested structure will be created even if the source value was not available on the source object.
   - if *false* then structure will only be create if the source value was available on the source object.
 
@@ -81,20 +81,20 @@ The ```createMapper()``` function now takes an (optional) options parameter to c
 const createMapper = require("map-factory");
 
 const options = {
-  alwaysTransform: false,
-  alwaysSet: false
+  alwaysTransform: true,
+  alwaysSet: true
 };
 
 const mapper = createMapper(options);
 ```
 ### Modify behaviour on a single mapping
 
-Additionally, you can also modify the behaviour on an individual mapping by using the ```always``` and ```existing``` modifier on the mapping like this:
+Additionally, you can also modify the behaviour on an individual mapping by using the ```always``` or ```existing``` modifiers on the mapping like this:
 
 ```js
 const createMapper = require("map-factory");
 
-const mapper = createMapper(options);
+const mapper = createMapper();
 
 mapper
   .map("a").always.to("b")

--- a/src/lib/map-factory.js
+++ b/src/lib/map-factory.js
@@ -5,9 +5,8 @@ export default function createMapper(options) {
 
   const opts = options || {};
 
-  // v1 will default as below but the reverse will be true in v2
-  opts.alwaysSet = typeof opts.alwaysSet === "boolean" ? opts.alwaysSet : true;
-  opts.alwaysTransform = typeof opts.alwaysTransform === "boolean" ? opts.alwaysTransform : true;
+  opts.alwaysSet = typeof opts.alwaysSet === "boolean" ? opts.alwaysSet : false;
+  opts.alwaysTransform = typeof opts.alwaysTransform === "boolean" ? opts.alwaysTransform : false;
   opts.experimental = typeof opts.experimental === "boolean" ? opts.experimental : false;
 
   const me = {

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -6,6 +6,8 @@ const SINGLE_MODE = 0;
 const MULTI_MODE = 1;
 const OR_MODE = 2;
 
+const isValueArray = new RegExp(/^\[\]|\[\d+\]/);
+
 export default class Mapper {
 
   constructor(opts, om) {
@@ -230,9 +232,20 @@ export default class Mapper {
       return this.om.setKeyValue(destinationObject, targetPath, value);
     }
 
+    if (this.isEmptyObject_(destinationObject) && isValueArray.exec(targetPath) !== null) {
+      return [];
+    }
+
     return destinationObject;
 
   }
+
+  isEmptyObject_(object) {
+    return typeof object === "object" &&
+      Array.isArray(object) === false &&
+      Object.keys(object).length === 0;
+  }
+
 
   exists_(value) {
     return (value !== null && value !== undefined);

--- a/src/test/arrays-test.js
+++ b/src/test/arrays-test.js
@@ -17,9 +17,6 @@ notationSuite.run(lab, {
     }
   },
   NO_SOURCE_EXPECTED: {
-    array: {
-      levels: []
-    }
   },
   MODIFY_VALUE: "modified",
   MODIFIED_EXPECTED: {

--- a/src/test/nested-properties-test.js
+++ b/src/test/nested-properties-test.js
@@ -20,7 +20,6 @@ suite.run(lab, {
     }
   },
   NO_SOURCE_EXPECTED: {
-    field: {}
   },
   MODIFY_VALUE: "modified",
   MODIFIED_EXPECTED: {

--- a/src/test/options-test.js
+++ b/src/test/options-test.js
@@ -18,8 +18,8 @@ group("when setting options", () => {
     const mapping = map("a");
 
     expect(mapping).to.be.an.object();
-    expect(mapping.alwaysSet).to.be.true();
-    expect(mapping.alwaysTransform).to.be.true();
+    expect(mapping.alwaysSet).to.be.false();
+    expect(mapping.alwaysTransform).to.be.false();
 
     return done();
 
@@ -32,8 +32,8 @@ group("when setting options", () => {
     const mapping = map("a");
 
     expect(mapping).to.be.an.object();
-    expect(mapping.alwaysSet).to.be.true();
-    expect(mapping.alwaysTransform).to.be.true();
+    expect(mapping.alwaysSet).to.be.false();
+    expect(mapping.alwaysTransform).to.be.false();
 
     return done();
 
@@ -41,13 +41,13 @@ group("when setting options", () => {
 
   lab.test("sets the alwaysTransform option correctly", done => {
 
-    const map = createMapper({ alwaysTransform: false });
+    const map = createMapper({ alwaysTransform: true });
 
     const mapping = map("a");
 
     expect(mapping).to.be.an.object();
-    expect(mapping.alwaysSet).to.be.true();
-    expect(mapping.alwaysTransform).to.be.false();
+    expect(mapping.alwaysSet).to.be.false();
+    expect(mapping.alwaysTransform).to.be.true();
 
     return done();
 
@@ -55,13 +55,13 @@ group("when setting options", () => {
 
   lab.test("sets the alwaysSet option correctly", done => {
 
-    const map = createMapper({ alwaysSet: false });
+    const map = createMapper({ alwaysSet: true });
 
     const mapping = map("a");
 
     expect(mapping).to.be.an.object();
-    expect(mapping.alwaysSet).to.be.false();
-    expect(mapping.alwaysTransform).to.be.true();
+    expect(mapping.alwaysSet).to.be.true();
+    expect(mapping.alwaysTransform).to.be.false();
 
     return done();
 

--- a/src/test/suites/empty-source-suite.js
+++ b/src/test/suites/empty-source-suite.js
@@ -54,12 +54,26 @@ suite.declare((lab, variables) => {
 
       });
 
-      lab.test("the target field does get created with a modifying transform", done => {
+      lab.test("the target field does not get created with a modifying transform", done => {
 
         const mapper = createSut();
 
         const actual = mapper
           .map(GET_ITEM).to(SET_ITEM, () => MODIFY_VALUE)
+          .execute({});
+
+        expect(actual).to.equal(NO_SOURCE_EXPECTED);
+
+        return done();
+
+      });
+
+      lab.test("the target field does get created with a modifying transform with always flag", done => {
+
+        const mapper = createSut();
+
+        const actual = mapper
+          .map(GET_ITEM).always.to(SET_ITEM, () => MODIFY_VALUE)
           .execute({});
 
         expect(actual).to.equal(MODIFIED_EXPECTED);
@@ -82,7 +96,21 @@ suite.declare((lab, variables) => {
 
       });
 
-      lab.test("the target field does get created for an array source with a modifying transform", done => {
+      lab.test("the target field does get created for an array source with a modifying transform with always flag", done => {
+
+        const mapper = createSut();
+
+        const actual = mapper
+          .map([GET_ITEM]).always.to(SET_ITEM, () => MODIFY_VALUE)
+          .execute({});
+
+        expect(actual).to.equal(MODIFIED_EXPECTED);
+
+        return done();
+
+      });
+
+      lab.test("the target field does not get created for an array source with a modifying transform", done => {
 
         const mapper = createSut();
 
@@ -90,7 +118,7 @@ suite.declare((lab, variables) => {
           .map([GET_ITEM]).to(SET_ITEM, () => MODIFY_VALUE)
           .execute({});
 
-        expect(actual).to.equal(MODIFIED_EXPECTED);
+        expect(actual).to.equal(NO_SOURCE_EXPECTED);
 
         return done();
 

--- a/src/test/suites/interface-suite.js
+++ b/src/test/suites/interface-suite.js
@@ -975,7 +975,7 @@ suite.declare((lab, variables) => {
 
       const map = createSut();
 
-      map("foo.bar").to("bar.bar?");
+      map("foo.bar").always.to("bar.bar?");
       map("a").to("foo.a");
 
       const result = map.execute(obj);

--- a/src/test/value-arrays-test.js
+++ b/src/test/value-arrays-test.js
@@ -5,7 +5,7 @@ import manyMappings from "./suites/many-mappings-suite";
 const lab = exports.lab = Lab.script();
 
 notationSuite.run(lab, {
-  LABELS: ["value arrays", "single mapping array"],
+  LABELS: ["value arrays", "single mapping array specifying index"],
   GET_ITEM: "item",
   SET_ITEM: "[0]",
   SOURCE: {
@@ -16,6 +16,20 @@ notationSuite.run(lab, {
   MODIFY_VALUE: "modified",
   MODIFIED_EXPECTED: ["modified"]
 });
+
+notationSuite.run(lab, {
+  LABELS: ["value arrays", "single mapping array"],
+  GET_ITEM: "item",
+  SET_ITEM: "[]",
+  SOURCE: {
+    item: 123
+  },
+  EXPECTED: [123],
+  NO_SOURCE_EXPECTED: [],
+  MODIFY_VALUE: "modified",
+  MODIFIED_EXPECTED: ["modified"]
+});
+
 
 // size is missing from source
 const labels = ["value arrays", "mix of available and missing data"];


### PR DESCRIPTION
In ```v1``` the default behaviour was the equivalent of setting the options as ```{alwaysTransform: true, alwaysSet: true}```. In ```v2``` the default behaviour is now the equivalent of setting the options as ```{alwaysTransform: false, alwaysSet: false}```. 

I think these are better defaults. This is a **breaking** change.

If you prefer the ```v1``` behaviour you just need to change your code as follows:

#### Old Code
```js
const mapper = createMapper();
```

#### New Code
```js
const options = {
  alwaysTransform: true,
  alwaysSet: true
};

const mapper = createMapper(options);
```

Additionally, the ```v1``` behaviour would consider a null an acceptable value if a ```?``` was appended to the ```to()``` field. In ```v2``` this behaviour will only work in combination with the ```always``` flag.

#### Old Code
```js
map("foo.bar").to("bar.bar?");
```

#### New Code
```js
map("foo.bar").always.to("bar.bar?");
```