### PR TITLE
Feature/chain

### DIFF
--- a/src/lib/interfaces.d.ts
+++ b/src/lib/interfaces.d.ts
@@ -12,6 +12,7 @@ export interface IMapFactory {
     execute(source: any, destination?: any): any;
     executeAsync(source: any, destination?: any): Promise<any>;
     each(sourceArray: any[]): any;
+    chain(mapper: IMapFactory):IMapFactory;
 }
 export interface IMapping {
     orMode: boolean;
@@ -24,6 +25,7 @@ export interface IMapping {
     execute(source: any, destination?: any): any;
     executeAsync(source: any, destination?: any): Promise<any>;
     each(sourceArray: any[]): any;
+    chain(mapper: IMapFactory):IMapFactory;
 }
 export interface IOptions {
   experimental?: boolean;

--- a/src/lib/map-factory.js
+++ b/src/lib/map-factory.js
@@ -37,5 +37,9 @@ export default function createMapper(options) {
     return this.mapper.each(sourceArray);
   }.bind(me);
 
+  mapper.chain = function (secondaryMapper) {
+    return this.mapper.chain(secondaryMapper);
+  }.bind(me);
+
   return mapper;
 }

--- a/src/lib/mapper.d.ts
+++ b/src/lib/mapper.d.ts
@@ -1,4 +1,4 @@
-import { IMapping } from "./interfaces";
+import { IMapping, IMapFactory } from "./interfaces";
 import Mapping from "./mapping";
 export default class Mapper {
     constructor(options, om);
@@ -9,6 +9,7 @@ export default class Mapper {
     each(sourceArray: any[]): any[];
     execute(source: any, destination: any): any;
     executeAsync(source: any, destination: any): Promise<any>;
+    chain(mapper: IMapFactory):IMapFactory;
     private createMapData();
     private appendMultiSelections(source, target, multiMaps);
     private applyOrMode(item, source, output);

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -19,6 +19,8 @@ export default class Mapper {
     this.assignment = [];
     this.mapCache_ = null;
 
+    this.chainArray = [];
+
   }
 
   registerMapping_(mapping) {
@@ -105,12 +107,23 @@ export default class Mapper {
 
     }
 
+    if (this.chainArray.length > 0) {
+      this.chainArray.map(item => {
+        destination = item.execute(destination);
+      });
+    }
+
     return destination;
   }
 
   executeAsync(source, destination) {
     return Promise.resolve()
       .then(() => this.execute(source, destination));
+  }
+
+  chain(mapper) {
+    this.chainArray.push(mapper);
+    return this;
   }
 
   getTransformDescriptor_(item) {

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -122,6 +122,9 @@ export default class Mapper {
   }
 
   chain(mapper) {
+    if (mapper === null || mapper === undefined) {
+      throw new Error("mapper passed in chain can neither be null or undefined");
+    }
     this.chainArray.push(mapper);
     return this;
   }

--- a/src/lib/mapping.d.ts
+++ b/src/lib/mapping.d.ts
@@ -1,4 +1,4 @@
-import { IMapping } from "./interfaces";
+import { IMapping, IMapFactory } from "./interfaces";
 export default class Mapping implements IMapping {
   source: string | string[];
   target: string;
@@ -10,6 +10,7 @@ export default class Mapping implements IMapping {
   or(source: string): this;
   execute(source?: any, destination?: any): any;
   executeAsync(source?: any, destination?: any): Promise<any>;
+  chain(mapper: IMapFactory):IMapFactory;
   each(sourceArray: any): any;
   to(target: string, fnc?: Function): any;
   always: IMapping;

--- a/src/lib/mapping.js
+++ b/src/lib/mapping.js
@@ -79,6 +79,10 @@ export default class Mapping {
     return this.mapper.each(sourceArray);
   }
 
+  chain(mapper) {
+    return this.mapper.chain(mapper);
+  }
+
   to(target, fnc) {
 
     if (!target || typeof target !== "string") {

--- a/src/test/chain-test.js
+++ b/src/test/chain-test.js
@@ -1,0 +1,57 @@
+import * as Lab from "lab";
+import { expect, fail } from "code";
+import createMapper from "../lib";
+
+const { describe, it, beforeEach } = exports.lab = Lab.script();
+const source = {
+  "foo": "bar",
+  "bar": "foo"
+};
+const expected = {
+  "bar": "bar"
+};
+let mapper;
+let secondaryMapper;
+
+describe("Chain functionality of the mapper", () => {
+
+  beforeEach(done => {
+    mapper = createMapper();
+    secondaryMapper = createMapper();
+    done();
+  });
+
+  describe("when chain is called from the mapper instance", () => {
+
+    it("should return response with the desired result", done => {
+      mapper.map("foo");
+      secondaryMapper.map("foo").to("bar");
+      expect(mapper.chain(secondaryMapper).execute(source)).to.equal(expected);
+      done();
+    });
+  });
+
+  describe("when chain is called from the default function", () => {
+
+    it("should return response with the desired result", done => {
+      secondaryMapper.map("foo").to("bar");
+      const actual = mapper
+        .map("foo")
+        .chain(secondaryMapper)
+        .execute(source);
+
+      expect(actual).to.equal(expected);
+      done();
+    });
+  });
+
+  describe("when chain is called", () => {
+
+    it("should return a response with the desired result", done => {
+      secondaryMapper.map("foo").to("bar");
+      const actual = mapper("foo").chain(secondaryMapper).execute(source);
+      expect(actual).to.equal(expected);
+      done();
+    });
+  });
+});

--- a/src/test/chain-test.js
+++ b/src/test/chain-test.js
@@ -1,5 +1,5 @@
 import * as Lab from "lab";
-import { expect, fail } from "code";
+import { expect } from "code";
 import createMapper from "../lib";
 
 const { describe, it, beforeEach } = exports.lab = Lab.script();
@@ -33,20 +33,6 @@ describe("Chain functionality of the mapper", () => {
 
   describe("when chain is called from the default function", () => {
 
-    it("should return response with the desired result", done => {
-      secondaryMapper.map("foo").to("bar");
-      const actual = mapper
-        .map("foo")
-        .chain(secondaryMapper)
-        .execute(source);
-
-      expect(actual).to.equal(expected);
-      done();
-    });
-  });
-
-  describe("when chain is called", () => {
-
     it("should return a response with the desired result", done => {
       secondaryMapper.map("foo").to("bar");
       const actual = mapper("foo").chain(secondaryMapper).execute(source);
@@ -54,4 +40,16 @@ describe("Chain functionality of the mapper", () => {
       done();
     });
   });
+
+  describe("when chain is called without any params", () => {
+
+    it("should throw an error", done => {
+      expect(() => mapper
+        .map("foo")
+        .chain()
+        .execute(source)).to.throw("mapper passed in chain can neither be null or undefined");
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
The functionality allows us to support chaining of two or more mappers to create the desired result.

```
const source = {
  "foo": "bar",
  "bar": "foo"
};

 const mapper = createMapper();
 const secondaryMapper = createMapper();

mapper.map("foo");
secondaryMapper.map("foo").to("bar");

const result = mapper.chain(secondaryMapper).execute(source);

/**
The expected result will be
{
  "bar": "bar"
}
**/
```