### PR TITLE
return empty array from each method of map-factory

### DIFF
--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -53,18 +53,10 @@ export default class Mapper {
       throw new Error("The sourceArray parameter must be an array");
     }
 
+    // iterate over an array of values and map each one
     return sourceArray.map(item => {
       return this.execute(item, null);
     });
-    // // iterate over an array of values and map each one
-    // if (sourceArray.length > 0) {
-    //   return sourceArray.map(item => {
-    //     return this.execute(item, null);
-    //   });
-    // }
-    //
-    // // TODO: This should probably return undefined
-    // return null;
   }
 
   execute(source, destination) {

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -53,15 +53,18 @@ export default class Mapper {
       throw new Error("The sourceArray parameter must be an array");
     }
 
-    // iterate over an array of values and map each one
-    if (sourceArray.length > 0) {
-      return sourceArray.map(item => {
-        return this.execute(item, null);
-      });
-    }
-
-    // TODO: This should probably return undefined
-    return null;
+    return sourceArray.map(item => {
+      return this.execute(item, null);
+    });
+    // // iterate over an array of values and map each one
+    // if (sourceArray.length > 0) {
+    //   return sourceArray.map(item => {
+    //     return this.execute(item, null);
+    //   });
+    // }
+    //
+    // // TODO: This should probably return undefined
+    // return null;
   }
 
   execute(source, destination) {

--- a/src/test/suites/interface-suite.js
+++ b/src/test/suites/interface-suite.js
@@ -471,7 +471,7 @@ suite.declare((lab, variables) => {
     lab.test("An empty array does not cause an error", done => {
       const source = [];
 
-      const expected = null;
+      const expected = [];
 
       const map = createSut();
 


### PR DESCRIPTION
the previous version of map-factory return null to avoid setting of an empty array as a value on the source object. As now this is handled at a global level, the each method now can safely return the empty array if the source is an empty array.
```
const mapper = createMapper();
mapper.map("a");
mapper.each([]); // should return [] instead of null
```