### PR TITLE
Adding a set functionality

### DIFF
--- a/src/lib/map-factory.js
+++ b/src/lib/map-factory.js
@@ -30,6 +30,10 @@ export default function createMapper(options) {
 
   }.bind(me);
 
+  mapper.set = function (key, value) {
+    return this.mapper.set(key, value);
+  }.bind(me);
+
   mapper.execute = function (source, destination) {
     return this.mapper.execute(source, destination);
   }.bind(me);

--- a/src/lib/mapper.d.ts
+++ b/src/lib/mapper.d.ts
@@ -6,6 +6,7 @@ export default class Mapper {
     private mapCache;
     registerMapping(mapping: IMapping): void;
     map(source: string | string[]): Mapping;
+    set(key: string, value: any): Mapping;
     each(sourceArray: any[]): any[];
     execute(source: any, destination: any): any;
     executeAsync(source: any, destination: any): Promise<any>;

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -42,6 +42,9 @@ export default class Mapper {
   }
 
   set(key, value) {
+    if (typeof key !== "string") {
+      throw new Error("the key must be a string");
+    }
     if (typeof value === "function") {
       return this.map(key).always.to(key, value);
     }

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -41,6 +41,13 @@ export default class Mapper {
 
   }
 
+  set(key, value) {
+    if (typeof value === "function") {
+      return this.map(key).always.to(key, value);
+    }
+    return this.map(key).always.to(key, () => value);
+  }
+
   each(sourceArray) {
 
     // validate inputs

--- a/src/test/examples-test.js
+++ b/src/test/examples-test.js
@@ -12,30 +12,39 @@ const { getValue, setValue } = createMapper;
 
 group("examples", () => {
 
-  lab.test("Set a field in the destination", done => {
+  lab.describe("set method", () => {
+    lab.test("Set a field in the destination", done => {
 
-    const expected = {
-      "foo": "bar",
-      "fooFunc": "bar"
-    };
+      const expected = {
+        "foo": "bar",
+        "fooFunc": "bar"
+      };
 
-    // Start example
+      // Start example
 
-    const source = {};
+      const source = {};
 
-    const mapper = createMapper();
+      const mapper = createMapper();
 
-    mapper.set("foo", "bar")
-      .set("fooFunc", () => "bar");
+      mapper.set("foo", "bar")
+        .set("fooFunc", () => "bar");
 
-    const result = mapper.execute(source);
+      const result = mapper.execute(source);
 
-    // End example
+      // End example
+      expect(result).to.equal(expected);
 
+      return done();
+    });
 
-    expect(result).to.equal(expected);
+    lab.test("Should throw error when set field is called with a key of type other than string", done => {
 
-    return done();
+      const mapper = createMapper();
+
+      expect(() => mapper.set(null, "bar")).to.throw("the key must be a string");
+
+      return done();
+    });
   });
 
   lab.test("Map a source field to the same object structure", done => {
@@ -206,12 +215,12 @@ group("examples", () => {
     const childMapper = createMapper();
 
     childMapper
-      .map("value").to("item");
+    .map("value").to("item");
 
     mainMapper
-      .map("one").to("one", array => childMapper.each(array))
-      .map("two").to("two", array => childMapper.each(array))
-      .map("three").to("three", array => childMapper.each(array));
+    .map("one").to("one", array => childMapper.each(array))
+    .map("two").to("two", array => childMapper.each(array))
+    .map("three").to("three", array => childMapper.each(array));
 
     const actual = mainMapper.execute(source);
 
@@ -407,8 +416,6 @@ group("examples", () => {
   });
 
   lab.test("Or use multiple mappers and chain them together", done => {
-
-
     const expected = {
       "blog": {
         "post": {

--- a/src/test/examples-test.js
+++ b/src/test/examples-test.js
@@ -12,6 +12,32 @@ const { getValue, setValue } = createMapper;
 
 group("examples", () => {
 
+  lab.test("Set a field in the destination", done => {
+
+    const expected = {
+      "foo": "bar",
+      "fooFunc": "bar"
+    };
+
+    // Start example
+
+    const source = {};
+
+    const mapper = createMapper();
+
+    mapper.set("foo", "bar")
+      .set("fooFunc", () => "bar");
+
+    const result = mapper.execute(source);
+
+    // End example
+
+
+    expect(result).to.equal(expected);
+
+    return done();
+  });
+
   lab.test("Map a source field to the same object structure", done => {
 
     const expected = {


### PR DESCRIPTION
adding a set functionality to set the value of the non existence field in source.

```
const source = {};
const mapper = createMapper();

mapper.set("foo", "bar")
  .set("fooFunc", () => "bar");

const result = mapper.execute(source);

// result
 {
      "foo": "bar",
      "fooFunc": "bar"
 };
```