### PR TITLE
[keep][adding a functionality to keep selected keys only]

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash.compact": "^3.0.1",
     "lodash.flattendeep": "^4.4.0",
     "lodash.flattendepth": "^4.7.0",
+    "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2"
   }
 }

--- a/src/lib/mapping.d.ts
+++ b/src/lib/mapping.d.ts
@@ -16,6 +16,7 @@ export default class Mapping implements IMapping {
   always: IMapping;
   existing: IMapping;
   removing(keys: string | string[]): IMapping;
+  keep(keys: string | string[]): IMapping;
   acceptIf(key: string, comparison: any): IMapping;
   rejectIf(key: string, comparison: any): IMapping;
 }

--- a/src/lib/mapping.js
+++ b/src/lib/mapping.js
@@ -1,5 +1,6 @@
 import cloneDeep from "lodash.clonedeep";
 import unset from "lodash.unset";
+import set from "lodash.set";
 import compact from "lodash.compact";
 
 export default class Mapping {
@@ -216,6 +217,66 @@ export default class Mapping {
 
   }
 
+  keep(keys) {
+
+    if (Array.isArray(keys) && keys.length > 0) {
+      keys.map(key => {
+        if (typeof key !== "string") {
+          throw new Error("The keep method requires a string value or an array of strings");
+        }
+
+      });
+    }
+
+    if (Array.isArray(keys) === false && typeof keys !== "string") {
+      throw new Error("The keep method requires a string value or an array of strings");
+    }
+
+    this.pushToPipelineTransformations_((source, value) => {
+
+      let valueToUse = cloneDeep(value);
+
+      if (typeof valueToUse !== "object" && !Array.isArray(valueToUse)) {
+        return valueToUse;
+      }
+
+      const isArray = Array.isArray(valueToUse) && valueToUse.length > 0;
+
+      if (isArray) {
+        valueToUse = valueToUse.map(val => {
+          if (typeof val !== "object" && !Array.isArray(val)) {
+            return val;
+          }
+          return this.processKeep_(keys, val);
+        });
+      } else {
+        valueToUse = this.processKeep_(keys, valueToUse);
+      }
+      return valueToUse;
+    });
+
+    return this;
+  }
+
+  processKeep_(keys, val) {
+
+    const obj = {};
+
+    if (Array.isArray(keys) && keys.length > 0) {
+      keys.map(key => {
+        set(obj, key, val[key]);
+      });
+
+      return obj;
+    }
+
+    if (typeof keys === "string") {
+      set(obj, keys, val[keys]);
+      return obj;
+    }
+
+  }
+
   removing(keys) {
 
     if (Array.isArray(keys) && keys.length > 0) {
@@ -273,6 +334,4 @@ export default class Mapping {
     }
 
   }
-
-
 }

--- a/src/test/pipelineTransformations-test.js
+++ b/src/test/pipelineTransformations-test.js
@@ -381,4 +381,112 @@ describe("Pipeline transformations functionality of the mapper", () => {
     });
   });
 
+  describe("keep", () => {
+
+    before(done => {
+      mapper = createMapper();
+
+      mapper
+        .map("foo").keep(["foo1"]).to("bar")
+        .map(["foo", "h"]).keep(["bar"])
+        .to("barMulti", foo => {
+          return foo;
+        })
+        .map("fooArray").keep(["bar", "foo1"]).to("barArray")
+        .map("h").or("howdy").keep(["id"]).to("orTest")
+        .map("howdy")
+        .map("voila").to("voila", () => "hello");
+
+      source = {
+        "foo": {
+          "id": "fooID",
+          "bar": "tes",
+          "foo1": "bar2"
+        },
+        "fooArray": [{
+          "id": "fooID",
+          "bar": "tes",
+          "foo1": "bar2"
+        }],
+        "howdy": {
+          "id": "allow",
+          "id2": "allow2"
+        },
+        "voila": "a"
+      };
+
+      expected = {
+        "bar": {
+          "foo1": "bar2"
+        },
+        "barArray": [
+          {
+            "bar": "tes",
+            "foo1": "bar2"
+          }
+        ],
+        "barMulti": {
+          "bar": "tes"
+        },
+        "howdy": {
+          "id": "allow",
+          "id2": "allow2"
+        },
+        "orTest": {
+          "id": "allow"
+        },
+        "voila": "hello"
+      };
+      done();
+    });
+
+    describe("when an object is passed", () => {
+
+      it("should return the desired result", done => {
+        actual = mapper.execute(source);
+        expect(actual).to.equal(expected);
+        done();
+      });
+    });
+
+    describe("when an array of object is passed", () => {
+
+      it("should return the desired result", done => {
+        actual = mapper.each([source]);
+        expect(actual).to.equal([expected]);
+        done();
+      });
+    });
+
+    describe("parameter validation", () => {
+
+      beforeEach(done => {
+        mapper = createMapper();
+        done();
+      });
+
+      it("should throw an error on null", done => {
+        expect(() => mapper("foo").keep(null).to("bar")).to.throw("The keep method requires a string value or an array of strings");
+        done();
+      });
+
+      it("should throw an error on undefined", done => {
+        expect(() => mapper("foo").keep(undefined).to("bar")).to.throw("The keep method requires a string value or an array of strings");
+        done();
+      });
+
+      it("should throw an error when keys are not passed in as valid string", done => {
+        expect(() => mapper("foo").keep({}).to("bar")).to.throw("The keep method requires a string value or an array of strings");
+        done();
+      });
+
+      it("should throw an error when keys are not passed in as valid array of strings", done => {
+        expect(() => mapper("foo").keep([{}]).to("bar")).to.throw("The keep method requires a string value or an array of strings");
+        done();
+      });
+
+    });
+
+  });
+
 });


### PR DESCRIPTION
This will be the reverse of removing and allows the user to keep only the selected properties from the object.

```
const source = {
  "bar": 1,
  "bar2": 2
};
map("foo").keep(["bar"]).to("fooo");
```