### PR TITLE
Allow to map root object in the mapper

### DIFF
--- a/src/lib/mapper.d.ts
+++ b/src/lib/mapper.d.ts
@@ -5,7 +5,7 @@ export default class Mapper {
     assignment: IMapping[];
     private mapCache;
     registerMapping(mapping: IMapping): void;
-    map(source: string | string[]): Mapping;
+    map(source?: string | string[]): Mapping;
     set(key: string, value: any): Mapping;
     each(sourceArray: any[]): any[];
     execute(source: any, destination: any): any;

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -1,6 +1,7 @@
 import Mapping from "./mapping";
 import flattenDeep from "lodash.flattendeep";
 import flattenDepth from "lodash.flattendepth";
+import cloneDeep from "lodash.clonedeep";
 
 const SINGLE_MODE = 0;
 const MULTI_MODE = 1;
@@ -235,7 +236,13 @@ export default class Mapper {
   processSingleItem_(sourceObject, destinationObject, { targetPath, sourcePath, transform, flattenings, options }) {
 
     // Get source
-    let value = this.om.getValue(sourceObject, sourcePath);
+    let value;
+
+    if (!sourcePath) {
+      value = cloneDeep(sourceObject);
+    } else {
+      value = this.om.getValue(sourceObject, sourcePath);
+    }
     const flattening = flattenings[0];
 
     // default transformations
@@ -253,6 +260,9 @@ export default class Mapper {
     }
 
     // Set value on destination object
+    if (!targetPath) {
+      return value;
+    }
     return this.setIfRequired_(destinationObject, targetPath, value, options);
 
   }

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -193,7 +193,8 @@ export default class Mapper {
 
     // no target means that the source is used as the target (same number of arrays)
     // so in this scenario we just suppress flattening
-    if (targetPath === null || targetPath === undefined) {
+    // no source means copy the root object so we dont need this
+    if (targetPath === null || targetPath === undefined || sourcePath === null || sourcePath === undefined) {
       return { sourceCount: 0, targetCount: 0, flatten: false, inverted: flattenInverted };
     }
 
@@ -261,7 +262,8 @@ export default class Mapper {
 
     // Set value on destination object
     if (!targetPath) {
-      return value;
+      destinationObject = value;
+      return destinationObject;
     }
     return this.setIfRequired_(destinationObject, targetPath, value, options);
 

--- a/src/lib/mapping.d.ts
+++ b/src/lib/mapping.d.ts
@@ -6,7 +6,7 @@ export default class Mapping implements IMapping {
   mapper: any;
   orMode: boolean;
   constructor(source: string | string[], mapper: any);
-  map(stringOrArray: string | string[]): any;
+  map(stringOrArray?: string | string[]): any;
   or(source: string): this;
   execute(source?: any, destination?: any): any;
   executeAsync(source?: any, destination?: any): Promise<any>;

--- a/src/lib/mapping.js
+++ b/src/lib/mapping.js
@@ -6,11 +6,6 @@ import compact from "lodash.compact";
 export default class Mapping {
 
   constructor(source, mapper, options) {
-
-    if (!source) {
-      throw new Error("the source field name cannot be null");
-    }
-
     this.mapper = mapper;
     this.source = source;
     this.orMode = false;

--- a/src/test/suites/interface-suite.js
+++ b/src/test/suites/interface-suite.js
@@ -190,15 +190,28 @@ suite.declare((lab, variables) => {
 
       const map = createSut();
 
-      const result = map(null).execute({});
+      const result = map(null).execute({"foo": "bar"});
 
-      expect(result).to.equal({});
+      expect(result).to.equal({"foo": "bar"});
 
       return done();
 
     });
 
-    lab.test("A null source field should map the source to destination provided", done => {
+
+    lab.test("A no source field is provided should map the source to destination", done => {
+
+      const map = createSut();
+
+      const result = map().execute({"foo": "bar"});
+
+      expect(result).to.equal({"foo": "bar"});
+
+      return done();
+
+    });
+
+    lab.test(" A null source field can be used alongside a normal mapping", done => {
 
       const mapper = createSut();
 

--- a/src/test/suites/interface-suite.js
+++ b/src/test/suites/interface-suite.js
@@ -186,17 +186,33 @@ suite.declare((lab, variables) => {
       return done();
     });
 
-    lab.test("A null source field throws an error", done => {
+    lab.test("A null source field should map the source to destination", done => {
 
       const map = createSut();
 
-      const throws = function () {
+      const result = map(null).execute({});
 
-        map(null).to("field.name");
+      expect(result).to.equal({});
 
-      };
+      return done();
 
-      expect(throws).to.throw();
+    });
+
+    lab.test("A null source field should map the source to destination provided", done => {
+
+      const mapper = createSut();
+
+      mapper.map(null).to("test")
+        .map("foo").to("test.foo1");
+
+      const result = mapper.execute({"foo": "bar"});
+
+      expect(result).to.equal({
+        "test": {
+          "foo": "bar",
+          "foo1": "bar"
+        }
+      });
 
       return done();
 


### PR DESCRIPTION
This will allow the access to the root object to map.

```
mapper.map(null).to("test")
.map("foo").to("test.foo1");
const result = mapper.execute({"foo": "bar"});
```