### PR TITLE
[BUG][Keep transformation should not add the key if it is not present…

### DIFF
--- a/src/lib/mapping.js
+++ b/src/lib/mapping.js
@@ -263,7 +263,9 @@ export default class Mapping {
 
     if (Array.isArray(keys) && keys.length > 0) {
       keys.map(key => {
-        set(obj, key, val[key]);
+        if (val[key]) {
+          set(obj, key, val[key]);
+        }
       });
 
       return obj;

--- a/src/test/pipelineTransformations-test.js
+++ b/src/test/pipelineTransformations-test.js
@@ -387,7 +387,7 @@ describe("Pipeline transformations functionality of the mapper", () => {
       mapper = createMapper();
 
       mapper
-        .map("foo").keep(["foo1"]).to("bar")
+        .map("foo").keep(["foo1", "foo2"]).to("bar")
         .map(["foo", "h"]).keep(["bar"])
         .to("barMulti", foo => {
           return foo;


### PR DESCRIPTION
[Keep transformation should not add the key if it is not present in the source]

Current behaviour
```
const source = {
  "foo": {
      "foo1": "bar",
       "bar": "bar"
  }
}
mapper.map("foo").keep(["foo1", "foo2"]);

// result will be

 {
  "foo": {
      "foo1": "bar",
       "foo2": undefined
  }
}
```
Expected:---
```
// the result should be
 {
  "foo": {
      "foo1": "bar"
  }
}
```