### PR TITLE
Modifications in failure transform and adding an option to have a global failure transform

### DIFF
--- a/src/lib/interfaces.d.ts
+++ b/src/lib/interfaces.d.ts
@@ -31,4 +31,5 @@ export interface IOptions {
   experimental?: boolean;
   alwaysTransform?: boolean;
   alwaysSet?: boolean;
+  failureTransform?: Function
 }

--- a/src/lib/mapper.js
+++ b/src/lib/mapper.js
@@ -162,6 +162,10 @@ export default class Mapper {
       transform = value => value;
     }
 
+    if (!failureTransform && this.options.failureTransform) {
+      failureTransform = this.options.failureTransform;
+    }
+
     if (failureTransform && typeof failureTransform !== "function") {
       const valueToReturn = failureTransform;
       failureTransform = () => valueToReturn;
@@ -266,7 +270,7 @@ export default class Mapper {
     }
 
     if (!this.exists_(value) && failureTransform) {
-      value = failureTransform();
+      value = failureTransform(value);
     }
 
     // Set value on destination object
@@ -319,7 +323,7 @@ export default class Mapper {
     }
 
     if (!anyValues && failureTransform) {
-      value = failureTransform();
+      value = failureTransform(value);
     }
 
     // Set value on destination object
@@ -361,7 +365,7 @@ export default class Mapper {
     }
 
     if (!this.exists_(orValue) && failureTransform) {
-      orValue = failureTransform();
+      orValue = failureTransform(orValue);
     }
 
     return this.setIfRequired_(destinationObject, targetPath, orValue, options);

--- a/src/test/options-test.js
+++ b/src/test/options-test.js
@@ -632,10 +632,11 @@ group("the failureTransform as a option for default use", () => {
       "foo3": "from global",
       "fooOr": "from global",
       "foo4": "from global",
-      "foo5": "from global"
+      "foo5": "from global",
+      "fooNull": "foo"
     };
 
-    const mapper = createMapper({ failureTransform: () => "from global"});
+    const mapper = createMapper({ failureTransform: val => val === null ? "foo" : "from global"});
 
     mapper
       .map("foo1").to("foo1", null, "bar")
@@ -643,7 +644,8 @@ group("the failureTransform as a option for default use", () => {
       .map("foo2").to("foo5")
       .map(["foo1", "foo2"]).to("foo3", () => "check")
       .map("foo1").or("foo2").to("fooOr")
-      .map("foo4").always.to("foo4");
+      .map("foo4").always.to("foo4")
+      .map("fooNull").to("fooNull");
 
     const actual = mapper.execute(source);
 

--- a/src/test/options-test.js
+++ b/src/test/options-test.js
@@ -617,3 +617,38 @@ group("the existing modifier", () => {
   existingSuite.run(lab, { OPTIONS: { alwaysTransform: false, alwaysSet: true } });
 
 });
+
+group("the failureTransform as a option for default use", () => {
+  lab.test("should use the global failure transformed if its defined and failure transform is not provided as part of the mapping", done => {
+    const source = {
+      "foo": "name1",
+      "bar": "name2",
+      "fooNull": null
+    };
+
+    const expected = {
+      "foo1": "bar",
+      "foo2": "bar",
+      "foo3": "from global",
+      "fooOr": "from global",
+      "foo4": "from global",
+      "foo5": "from global"
+    };
+
+    const mapper = createMapper({ failureTransform: () => "from global"});
+
+    mapper
+      .map("foo1").to("foo1", null, "bar")
+      .map("foo2").to("foo2", null, () => "bar")
+      .map("foo2").to("foo5")
+      .map(["foo1", "foo2"]).to("foo3", () => "check")
+      .map("foo1").or("foo2").to("fooOr")
+      .map("foo4").always.to("foo4");
+
+    const actual = mapper.execute(source);
+
+    expect(actual).to.equal(expected);
+
+    return done();
+  });
+});

--- a/src/test/suites/interface-suite.js
+++ b/src/test/suites/interface-suite.js
@@ -671,7 +671,8 @@ suite.declare((lab, variables) => {
 
       const source = {
         "foo": "name1",
-        "bar": "name2"
+        "bar": "name2",
+        "fooNull": null
       };
 
       const expected = {
@@ -679,7 +680,8 @@ suite.declare((lab, variables) => {
         "foo2": "bar",
         "foo3": "bar",
         "fooOr": "barOr",
-        "foo4": "foo4"
+        "foo4": "foo4",
+        "fooNull": "true"
       };
 
       const mapper = createSut();
@@ -691,7 +693,8 @@ suite.declare((lab, variables) => {
         .map("foo1").or("foo2").to("fooOr", null, "barOr")
         .map("foo4").always.to("foo4", () => "foo4", () => "bar")
         .map("foo5").to("foo5", null, () => null)
-        .map("foo6").to("foo6", null, null);
+        .map("foo6").to("foo6", null, null)
+        .map("fooNull").to("fooNull", null, val => val === null ? "true" : "false");
 
       const actual = mapper.execute(source);
 


### PR DESCRIPTION
The pr allows the failure transform to pass the value either null or undefined to the function to make more informed decision based on the type.
```
const mapper = createMapper();

mapper
.map("foo").to("isfoo", null, val => val === null ? "true" : "false");

mapper.execute({"foo": null});

// result
{
  "isfoo": "true"
}
```

Map-factory will also allow passing a function in options to have a global failure transform which will be applied to the mapping if no failure transform is provided.

```
const mapper = createMapper({ failureTransform: () => "from global"});
mapper
 .map("foo1").to("foo1", null, "bar")
 .map("foo4").always.to("foo4");

mapper.execute({});

// result
{
  "foo1": "bar",
  "foo4": "from global"
}
```

