### PR TITLE
Re-export types to avoid typescript errors

### DIFF
--- a/src/lib/map-factory.d.ts
+++ b/src/lib/map-factory.d.ts
@@ -1,4 +1,5 @@
 import { IMapFactory, IOptions } from "./interfaces";
+export { IMapFactory, IOptions };
 export default function createMapper(options?: IOptions): IMapFactory;
 export function setValue(baseObject: any, destinationKey: string, fromValue: any): any;
 export function getValue(fromObject: any, fromKey: string): any;


### PR DESCRIPTION
When used library, typescript complain about types.